### PR TITLE
Add private playlist support and remove unused scopes

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <template is='dom-bind' id='binder'>
 
         <template is="dom-if" if='{{!token}}'>
-            <spotify-login scope="user-read-private user-follow-read user-read-email" client_id="a7b3de70814a40908fd482a8eb525878" on-spotify-logged='_func'></spotify-login>
+            <spotify-login scope="playlist-read-private" client_id="a7b3de70814a40908fd482a8eb525878" on-spotify-logged='_func'></spotify-login>
         </template>
         <template is="dom-if" if="{{token}}">
             <spotify-component token='{{token}}' refresh_time=60000 </spotify-component>


### PR DESCRIPTION
- *user-follow-read* is used to see other users/artist followed by the user -> NOT USED BY THE APP
- *user-read-private* is used to check the account subscription details -> NOT USED BY THE APP
- *user-read-email* is used to check the email associated to the user account -> NOT USED BY THE APP